### PR TITLE
adding fips build support

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,7 +1,7 @@
 ARG KUBECTL=rancher/kubectl:v1.21.9
 FROM ${KUBECTL} AS kubectl
 
-FROM registry.suse.com/bci/golang:1.17-11.33
+FROM golang:1.19-alpine
 
 COPY --from=kubectl /bin/kubectl /usr/local/bin/kubectl
 # COPY --from=sonobuoy /sonobuoy /usr/local/bin/sonobuoy
@@ -9,12 +9,7 @@ COPY --from=kubectl /bin/kubectl /usr/local/bin/kubectl
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN zypper -n install expect git jq  docker vim less file curl wget iproute2 gawk
-# Manual install of docker-compose, only needed for e2e tests on amd64
-RUN if [ "${ARCH}" == "amd64" ]; then \
-        curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64" -o /usr/local/bin/docker-compose && \
-        chmod +x /usr/local/bin/docker-compose; \
-    fi
+RUN apk -U add coreutils bash expect git gcc jq musl-dev docker docker-compose vim less file curl wget ca-certificates iproute2
 RUN go install github.com/mgechev/revive@v1.1.1 && \
     rm -rf /go/src /go/pkg
 RUN go install golang.org/x/tools/cmd/goimports@latest && \
@@ -22,8 +17,8 @@ RUN go install golang.org/x/tools/cmd/goimports@latest && \
 RUN if [ "$(go env GOARCH)" = "amd64" ]; then \
         curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.41.1; \
     fi
-RUN if [ "${ARCH}" == "amd64" ]; then \
-        go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4; \
+RUN if [ "${ARCH}" = "amd64" ]; then \
+        go install sigs.k8s.io/kustomize/kustomize/v5@latest; \
     fi
 ARG SONOBUOY_VERSION=0.56.2
 RUN if [ "${ARCH}" != "arm" ] && [ "${ARCH}" != "s390x" ]; then \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,22 +1,27 @@
-ARG SLES=registry.suse.com/suse/sle15:15.3
-ARG GOLANG=registry.suse.com/bci/golang:1.17-11.33
+ARG ALPINE=alpine:3.18
+ARG GOLANG=golang:1.19-alpine
 
 FROM ${GOLANG} AS e2e-ginkgo
 ENV GOBIN=/bin
-RUN go install github.com/onsi/ginkgo/ginkgo@v1.16.4
+RUN set -x \
+  && apk add --no-cache \
+     ca-certificates \
+     git \
+  && go install github.com/onsi/ginkgo/ginkgo@v1.16.4
 
-FROM ${SLES} AS e2e-tests
+FROM ${ALPINE} AS e2e-tests
 ARG ARCH
 ARG REPO=rancher
 ARG TAG
 ENV SYSTEM_UPGRADE_CONTROLLER_IMAGE=${REPO}/system-upgrade-controller:${TAG}
+RUN set -x \
+  && apk add --no-cache \
+     bash
 COPY --from=e2e-ginkgo /bin/ginkgo /bin/ginkgo
 COPY dist/artifacts/system-upgrade-controller.test-${ARCH} /bin/system-upgrade-controller.test
 COPY e2e/plugin/run.sh /run.sh
 RUN set -x \
  && chmod +x /run.sh
-RUN set -x \
- && zypper -n in tar gzip
 ENTRYPOINT ["/run.sh"]
 
 FROM scratch AS controller

--- a/scripts/build-fips
+++ b/scripts/build-fips
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/version
+
+cd $(dirname $0)/..
+
+mkdir -p bin
+echo "Building FIPS $PKG ..."
+LINKFLAGS="-linkmode=external -extldflags=-static -s"
+VERSIONFLAGS="-X ${PKG}/pkg/version.Version=${VERSION} -X ${PKG}/pkg/version.GitCommit=${COMMIT:0:8}"
+CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -ldflags "$VERSIONFLAGS $LINKFLAGS" -o bin/system-upgrade-controller

--- a/scripts/fips
+++ b/scripts/fips
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+./build-fips
+./test
+./validate
+./package


### PR DESCRIPTION
- switch back to alpine image (cgo_enabled=1 didn't work on suse)
- add fips build scrips

```
# for fips build
$ make fips

# for normal build
$ make ci 
# or just
$ make
```

```
$ docker images
REPOSITORY                          TAG                       IMAGE ID       CREATED          SIZE
rancher/system-upgrade-controller   8abd0dd-dirty-e2e-tests   94e685de455d   8 minutes ago    59.3MB
rancher/system-upgrade-controller   dev-e2e-tests             94e685de455d   8 minutes ago    59.3MB
rancher/system-upgrade-controller   latest-e2e-tests          94e685de455d   8 minutes ago    59.3MB
rancher/system-upgrade-controller   dev                       6690055322ca   8 minutes ago    29.7MB
rancher/system-upgrade-controller   latest                    6690055322ca   8 minutes ago    29.7MB
system-upgrade-controller           master                    1226431a3d18   9 minutes ago    1.43GB
```

```
$ strings bin/system-upgrade-controller | grep sig.Boring
crypto/internal/boring/sig.BoringCrypto

$ file bin/system-upgrade-controller 
bin/system-upgrade-controller: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=MsuUYfaCfrCd06BX9JUC/s0q9nnA9fXN6VPV6eByb/pCv9VNBrwRXH4JNrKH4n/0VBHrNmzVFZXdkbzGyJo, stripped
```