### PR TITLE
build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM --platform=$TARGETPLATFORM golang:1.19.10-alpine as builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG CRYPTO_LIB
+ENV GOEXPERIMENT=${CRYPTO_LIB:+boringcrypto}
+
+WORKDIR /workspace
+
+COPY . .
+
+RUN apk -U add coreutils bash expect git gcc musl-dev
+RUN apk --update add \
+    util-linux-dev
+RUN mkdir -p bin
+
+RUN if [ ${CRYPTO_LIB} ]; \
+    then \
+      CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build -ldflags "-linkmode=external -extldflags=-static" -a -o bin/system-upgrade-controller ;\
+    else \
+      CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o bin/system-upgrade-controller ;\
+    fi
+
+FROM --platform=$TARGETPLATFORM scratch AS controller
+WORKDIR /bin
+COPY --from=builder /workspace/bin/system-upgrade-controller .
+ENTRYPOINT ["/bin/system-upgrade-controller"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
 TARGETS := $(shell ls scripts)
 
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+GOPATH ?= $(shell go env GOPATH)
+TARGETARCH ?= amd64
+
+FIPS_ENABLE ?= ""
+
+IMG_PATH ?= "gcr.io/spectro-common-dev/${USER}"
+IMG_TAG ?= "latest"
+IMG_SERVICE_URL ?= ${IMG_PATH}/
+SUC_IMG ?= ${IMG_SERVICE_URL}system-upgrade-controller:${IMG_TAG}
+
 .dapper:
 	@echo Downloading dapper
 	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
@@ -15,6 +27,9 @@ e2e: e2e-sonobuoy
 
 clean:
 	rm -rvf ./bin ./dist
+
+docker:
+	docker buildx build --platform linux/${TARGETARCH} --load . -t ${SUC_IMG} --build-arg CRYPTO_LIB=${FIPS_ENABLE} -f Dockerfile
 
 .DEFAULT_GOAL := ci
 


### PR DESCRIPTION
- new target (docker) to build just the docker image
- new Dockerfile with FIPS and Platforms support

Notes: 
1. build for arm64 works only when builder platform also arm64
2. with arm64, FIPS check is failing when using `strings` and `goversion` reports as boringcrypto. ~~It may need a fix~~. Go1.19.x doesn't support ARM for FIPS.


```
# FIPS and ARM
FIPS_ENABLE=true TARGETARCH=arm64 make docker
```

```
$ file bin/system-upgrade-controller 
bin/system-upgrade-controller: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=TrZxg_twcy7KwVYqu5MJ/d9ZMfhHq3BcN-s6EDhfX/fOTBXuWUc1gUYvJ_19tJ/qA8p2M67gsGl556XEpF6, with debug_info, not stripped
```