### PR TITLE
fix(PCP-4074-fix2): AWS Microk8 cluster Download logs failed with invalid Job name formed

### DIFF
--- a/pkg/upgrade/job/job.go
+++ b/pkg/upgrade/job/job.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-
 )
 
 const (
@@ -102,7 +101,7 @@ func New(plan *upgradeapiv1.Plan, node *corev1.Node, controllerName string) *bat
 	shortNodeName := strings.SplitN(node.Name, ".", 2)[0]
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.SafeConcatName("apply", plan.Name, "on", shortNodeName, "with", plan.Status.LatestHash),
+			Name:      name.SafeConcatName("apply", plan.Name, "on", shortNodeName),
 			Namespace: plan.Namespace,
 			Annotations: labels.Set{
 				upgradeapi.AnnotationTTLSecondsAfterFinished: strconv.FormatInt(int64(TTLSecondsAfterFinished), 10),


### PR DESCRIPTION
Before this fix the job is failing because on the first run the LatestHash is not being populated in plan, but after sometime it gets populated, and that's why the job was succeeding on the later runs.